### PR TITLE
mod/icon fill

### DIFF
--- a/scripts/helpers/template.js
+++ b/scripts/helpers/template.js
@@ -15,7 +15,7 @@ function defaultTemplate(
   
   function ${componentRealName}(oldProps) {    
     const props = {
-      ...(oldProps.custom ? {} : { viewBox: '0 0 24 24', fill: 'var(--text)', height: 24, width: 24}),
+      ...(oldProps.custom ? {} : { viewBox: '0 0 24 24', fill: 'currentColor', height: 24, width: 24}),
       ...(oldProps.size ? {height: oldProps.size, width: oldProps.size} : {}),
       ...oldProps,
       size: undefined,


### PR DESCRIPTION
By setting currentColor in SVG, we can use color CSS property. (which will help in easy migration since we many classes are already attached with old IconStore implementation).